### PR TITLE
Fix/notification workflow

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -597,7 +597,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/notification/unread-count/{user_id}": {
+        "/notification/unread-count": {
             "get": {
                 "security": [
                     {
@@ -615,15 +615,6 @@ const docTemplate = `{
                     "notification"
                 ],
                 "summary": "Get unread notification count",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Unread notification count",
@@ -633,15 +624,6 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -433,7 +433,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/notification/read-all/{user_id}": {
+        "/notification/read-all": {
             "put": {
                 "security": [
                     {
@@ -451,15 +451,6 @@ const docTemplate = `{
                     "notification"
                 ],
                 "summary": "Mark all user notifications as read",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "All notifications marked as read",
@@ -467,26 +458,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/notification_handler.ReadAllUserNotificationsResponse"
                         }
                     },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
                     "404": {
-                        "description": "User not found",
+                        "description": "Notification not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -373,7 +373,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/notification/feed/{user_id}": {
+        "/notification/feed": {
             "get": {
                 "security": [
                     {
@@ -392,13 +392,6 @@ const docTemplate = `{
                 ],
                 "summary": "Get user notification feed",
                 "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    },
                     {
                         "type": "integer",
                         "description": "Page number (default: 1)",
@@ -421,15 +414,6 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -787,6 +787,15 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "403": {
                         "description": "Forbidden",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -427,7 +427,7 @@
                 }
             }
         },
-        "/notification/read-all/{user_id}": {
+        "/notification/read-all": {
             "put": {
                 "security": [
                     {
@@ -445,15 +445,6 @@
                     "notification"
                 ],
                 "summary": "Mark all user notifications as read",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "All notifications marked as read",
@@ -461,26 +452,8 @@
                             "$ref": "#/definitions/notification_handler.ReadAllUserNotificationsResponse"
                         }
                     },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
                     "404": {
-                        "description": "User not found",
+                        "description": "Notification not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -781,6 +781,15 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "403": {
                         "description": "Forbidden",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -591,7 +591,7 @@
                 }
             }
         },
-        "/notification/unread-count/{user_id}": {
+        "/notification/unread-count": {
             "get": {
                 "security": [
                     {
@@ -609,15 +609,6 @@
                     "notification"
                 ],
                 "summary": "Get unread notification count",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Unread notification count",
@@ -627,15 +618,6 @@
                     },
                     "400": {
                         "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -367,7 +367,7 @@
                 }
             }
         },
-        "/notification/feed/{user_id}": {
+        "/notification/feed": {
             "get": {
                 "security": [
                     {
@@ -386,13 +386,6 @@
                 ],
                 "summary": "Get user notification feed",
                 "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    },
                     {
                         "type": "integer",
                         "description": "Page number (default: 1)",
@@ -415,15 +408,6 @@
                     },
                     "400": {
                         "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1107,17 +1107,11 @@ paths:
       summary: Send notification
       tags:
       - notification
-  /notification/unread-count/{user_id}:
+  /notification/unread-count:
     get:
       consumes:
       - application/json
       description: Get the count of unread notifications for a user
-      parameters:
-      - description: User ID
-        in: path
-        name: user_id
-        required: true
-        type: integer
       produces:
       - application/json
       responses:
@@ -1127,12 +1121,6 @@ paths:
             $ref: '#/definitions/notification_handler.GetUnreadCountResponse'
         "400":
           description: Bad request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "403":
-          description: Forbidden
           schema:
             additionalProperties:
               type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -940,6 +940,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "403":
           description: Forbidden
           schema:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -963,17 +963,12 @@ paths:
       summary: Mark notification as read
       tags:
       - notification
-  /notification/feed/{user_id}:
+  /notification/feed:
     get:
       consumes:
       - application/json
       description: Get paginated list of notifications for a user
       parameters:
-      - description: User ID
-        in: path
-        name: user_id
-        required: true
-        type: integer
       - description: 'Page number (default: 1)'
         in: query
         name: page
@@ -991,12 +986,6 @@ paths:
             $ref: '#/definitions/notification_handler.GetUserNotificationFeedSwaggerResponse'
         "400":
           description: Bad request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "403":
-          description: Forbidden
           schema:
             additionalProperties:
               type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1001,17 +1001,11 @@ paths:
       summary: Get user notification feed
       tags:
       - notification
-  /notification/read-all/{user_id}:
+  /notification/read-all:
     put:
       consumes:
       - application/json
       description: Mark all notifications of a user as read
-      parameters:
-      - description: User ID
-        in: path
-        name: user_id
-        required: true
-        type: integer
       produces:
       - application/json
       responses:
@@ -1019,20 +1013,8 @@ paths:
           description: All notifications marked as read
           schema:
             $ref: '#/definitions/notification_handler.ReadAllUserNotificationsResponse'
-        "400":
-          description: Bad request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "403":
-          description: Forbidden
-          schema:
-            additionalProperties:
-              type: string
-            type: object
         "404":
-          description: User not found
+          description: Notification not found
           schema:
             additionalProperties:
               type: string

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -140,7 +140,7 @@ func (r *Router) setupNotificationRoutes(jwtMiddleware func(next http.Handler) h
 		r.Get("/feed", notificationHandler.GetUserNotificationFeed)
 		r.Get("/unread-count", notificationHandler.GetUnreadCount)
 		r.Put("/{notification_id}/read", notificationHandler.ReadNotification)
-		r.Put("/read-all/{user_id}", notificationHandler.ReadAllUserNotifications)
+		r.Put("/read-all", notificationHandler.ReadAllUserNotifications)
 		r.Delete("/{notification_id}", notificationHandler.RemoveNotification)
 		r.Post("/send", notificationHandler.SendNotification)
 	})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -137,7 +137,7 @@ func (r *Router) setupNotificationRoutes(jwtMiddleware func(next http.Handler) h
 	router.Group(func(r chi.Router) {
 		r.Use(jwtMiddleware)
 		r.Get("/{notification_id}", notificationHandler.GetNotificationDetails)
-		r.Get("/feed/{user_id}", notificationHandler.GetUserNotificationFeed)
+		r.Get("/feed", notificationHandler.GetUserNotificationFeed)
 		r.Get("/unread-count", notificationHandler.GetUnreadCount)
 		r.Put("/{notification_id}/read", notificationHandler.ReadNotification)
 		r.Put("/read-all/{user_id}", notificationHandler.ReadAllUserNotifications)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -138,7 +138,7 @@ func (r *Router) setupNotificationRoutes(jwtMiddleware func(next http.Handler) h
 		r.Use(jwtMiddleware)
 		r.Get("/{notification_id}", notificationHandler.GetNotificationDetails)
 		r.Get("/feed/{user_id}", notificationHandler.GetUserNotificationFeed)
-		r.Get("/unread-count/{user_id}", notificationHandler.GetUnreadCount)
+		r.Get("/unread-count", notificationHandler.GetUnreadCount)
 		r.Put("/{notification_id}/read", notificationHandler.ReadNotification)
 		r.Put("/read-all/{user_id}", notificationHandler.ReadAllUserNotifications)
 		r.Delete("/{notification_id}", notificationHandler.RemoveNotification)

--- a/internal/clients/notification/notification.go
+++ b/internal/clients/notification/notification.go
@@ -212,7 +212,7 @@ func (c *notificationClient) ReadAllUserNotifications(ctx context.Context, userI
 			case codes.InvalidArgument:
 				return custom_errors.ErrValidationFailed
 			case codes.NotFound:
-				return custom_errors.ErrUserNotFound
+				return custom_errors.ErrNotificationNotFound
 			case codes.PermissionDenied:
 				return custom_errors.ErrInsufficientRights
 			case codes.Unavailable:

--- a/internal/clients/notification/notification.go
+++ b/internal/clients/notification/notification.go
@@ -47,7 +47,7 @@ func (c *notificationClient) SendNotification(ctx context.Context, userID int64,
 			case codes.ResourceExhausted:
 				return 0, custom_errors.ErrNotificationLimitExceeded
 			case codes.AlreadyExists:
-				return 0, custom_errors.ErrNotificationAlreadyExists // Исправлено с ErrAlreadyFollowing
+				return 0, custom_errors.ErrNotificationAlreadyExists
 			case codes.Unavailable:
 				return 0, custom_errors.ErrExternalServiceUnavailable
 			case codes.DeadlineExceeded:

--- a/internal/handlers/notification/get_notification_details.go
+++ b/internal/handlers/notification/get_notification_details.go
@@ -52,6 +52,9 @@ func (h *NotificationHandler) GetNotificationDetails(w http.ResponseWriter, r *h
 			case codes.NotFound:
 				utils.SendError(w, http.StatusNotFound, custom_errors.ErrNotificationNotFound.Error())
 				return
+			case codes.InvalidArgument:
+				utils.SendError(w, http.StatusBadRequest, custom_errors.ErrValidationFailed.Error())
+				return
 			case codes.PermissionDenied:
 				utils.SendError(w, http.StatusForbidden, custom_errors.ErrInsufficientRights.Error())
 				return
@@ -67,6 +70,9 @@ func (h *NotificationHandler) GetNotificationDetails(w http.ResponseWriter, r *h
 			return
 		case errors.Is(err, custom_errors.ErrNotificationAccessDenied):
 			utils.SendError(w, http.StatusForbidden, custom_errors.ErrNotificationAccessDenied.Error())
+			return
+		case errors.Is(err, custom_errors.ErrValidationFailed):
+			utils.SendError(w, http.StatusBadRequest, custom_errors.ErrValidationFailed.Error())
 			return
 		default:
 			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())

--- a/internal/handlers/notification/get_unread_count.go
+++ b/internal/handlers/notification/get_unread_count.go
@@ -53,7 +53,7 @@ func (h *NotificationHandler) GetUnreadCount(w http.ResponseWriter, r *http.Requ
 			slog.Int64("request_user_id", userID),
 			slog.Int64("authenticated_user_id", claims.UserID),
 		)
-		utils.SendError(w, http.StatusForbidden, custom_errors.ErrInsufficientRights.Error())
+		utils.SendError(w, http.StatusForbidden, custom_errors.ErrForbidden.Error())
 		return
 	}
 
@@ -67,7 +67,7 @@ func (h *NotificationHandler) GetUnreadCount(w http.ResponseWriter, r *http.Requ
 				utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
 				return
 			case codes.PermissionDenied:
-				utils.SendError(w, http.StatusForbidden, custom_errors.ErrInsufficientRights.Error())
+				utils.SendError(w, http.StatusForbidden, custom_errors.ErrForbidden.Error())
 				return
 			case codes.Internal:
 				utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
@@ -80,7 +80,7 @@ func (h *NotificationHandler) GetUnreadCount(w http.ResponseWriter, r *http.Requ
 			utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
 			return
 		case errors.Is(err, custom_errors.ErrNotificationAccessDenied):
-			utils.SendError(w, http.StatusForbidden, custom_errors.ErrNotificationAccessDenied.Error())
+			utils.SendError(w, http.StatusForbidden, custom_errors.ErrForbidden.Error())
 			return
 		default:
 			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())

--- a/internal/handlers/notification/get_unread_count.go
+++ b/internal/handlers/notification/get_unread_count.go
@@ -2,16 +2,13 @@ package notification_handler
 
 import (
 	"errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"log/slog"
 	"net/http"
 	"pinstack-api-gateway/internal/custom_errors"
 	"pinstack-api-gateway/internal/middlewares"
 	"pinstack-api-gateway/internal/utils"
-	"strconv"
-
-	"github.com/go-chi/chi/v5"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type GetUnreadCountResponse struct {
@@ -25,21 +22,11 @@ type GetUnreadCountResponse struct {
 // @Accept json
 // @Produce json
 // @Security BearerAuth
-// @Param user_id path int true "User ID"
 // @Success 200 {object} GetUnreadCountResponse "Unread notification count"
 // @Failure 400 {object} map[string]string "Bad request"
-// @Failure 403 {object} map[string]string "Forbidden"
 // @Failure 500 {object} map[string]string "Internal server error"
-// @Router /notification/unread-count/{user_id} [get]
+// @Router /notification/unread-count [get]
 func (h *NotificationHandler) GetUnreadCount(w http.ResponseWriter, r *http.Request) {
-	userIDStr := chi.URLParam(r, "user_id")
-	userID, err := strconv.ParseInt(userIDStr, 10, 64)
-	if err != nil {
-		h.log.Debug("Failed to parse user ID", slog.String("user_id", userIDStr), slog.String("error", err.Error()))
-		utils.SendError(w, http.StatusBadRequest, custom_errors.ErrInvalidInput.Error())
-		return
-	}
-
 	claims, err := middlewares.GetClaimsFromContext(r.Context())
 	if err != nil {
 		h.log.Debug("No user claims in context", slog.String("error", err.Error()))
@@ -47,27 +34,14 @@ func (h *NotificationHandler) GetUnreadCount(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if claims.UserID != userID {
-		h.log.Debug(
-			"User not authorized to get unread notifications count for other users",
-			slog.Int64("request_user_id", userID),
-			slog.Int64("authenticated_user_id", claims.UserID),
-		)
-		utils.SendError(w, http.StatusForbidden, custom_errors.ErrForbidden.Error())
-		return
-	}
-
-	count, err := h.notificationClient.GetUnreadCount(r.Context(), userID)
+	count, err := h.notificationClient.GetUnreadCount(r.Context(), claims.UserID)
 	if err != nil {
-		h.log.Error("Failed to get unread notification count", slog.Int64("user_id", userID), slog.String("error", err.Error()))
+		h.log.Error("Failed to get unread notification count", slog.Int64("user_id", claims.UserID), slog.String("error", err.Error()))
 
 		if st, ok := status.FromError(err); ok {
 			switch st.Code() {
 			case codes.NotFound:
 				utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
-				return
-			case codes.PermissionDenied:
-				utils.SendError(w, http.StatusForbidden, custom_errors.ErrForbidden.Error())
 				return
 			case codes.Internal:
 				utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
@@ -78,9 +52,6 @@ func (h *NotificationHandler) GetUnreadCount(w http.ResponseWriter, r *http.Requ
 		switch {
 		case errors.Is(err, custom_errors.ErrUserNotFound):
 			utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
-			return
-		case errors.Is(err, custom_errors.ErrNotificationAccessDenied):
-			utils.SendError(w, http.StatusForbidden, custom_errors.ErrForbidden.Error())
 			return
 		default:
 			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())

--- a/internal/handlers/notification/get_user_notification_feed.go
+++ b/internal/handlers/notification/get_user_notification_feed.go
@@ -102,6 +102,8 @@ func (h *NotificationHandler) GetUserNotificationFeed(w http.ResponseWriter, r *
 		return
 	}
 
+	h.log.Debug("notifications from client", slog.Any("notifications", notifications), slog.String("total", string(total)))
+
 	var totalPages int32
 	if total%limit == 0 {
 		totalPages = total / limit
@@ -116,6 +118,8 @@ func (h *NotificationHandler) GetUserNotificationFeed(w http.ResponseWriter, r *
 		Limit:         int(limit),
 		TotalPages:    int(totalPages),
 	}
+
+	h.log.Debug("Get user notification feed response", slog.Any("response", response))
 
 	utils.Send(w, http.StatusOK, response)
 }

--- a/internal/handlers/notification/read_all_user_notifications.go
+++ b/internal/handlers/notification/read_all_user_notifications.go
@@ -2,16 +2,13 @@ package notification_handler
 
 import (
 	"errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"log/slog"
 	"net/http"
 	"pinstack-api-gateway/internal/custom_errors"
 	"pinstack-api-gateway/internal/middlewares"
 	"pinstack-api-gateway/internal/utils"
-	"strconv"
-
-	"github.com/go-chi/chi/v5"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type ReadAllUserNotificationsResponse struct {
@@ -26,22 +23,11 @@ type ReadAllUserNotificationsResponse struct {
 // @Accept json
 // @Produce json
 // @Security BearerAuth
-// @Param user_id path int true "User ID"
 // @Success 200 {object} ReadAllUserNotificationsResponse "All notifications marked as read"
-// @Failure 400 {object} map[string]string "Bad request"
-// @Failure 403 {object} map[string]string "Forbidden"
-// @Failure 404 {object} map[string]string "User not found"
+// @Failure 404 {object} map[string]string "Notification not found"
 // @Failure 500 {object} map[string]string "Internal server error"
-// @Router /notification/read-all/{user_id} [put]
+// @Router /notification/read-all [put]
 func (h *NotificationHandler) ReadAllUserNotifications(w http.ResponseWriter, r *http.Request) {
-	userIDStr := chi.URLParam(r, "user_id")
-	userID, err := strconv.ParseInt(userIDStr, 10, 64)
-	if err != nil {
-		h.log.Debug("Failed to parse user ID", slog.String("user_id", userIDStr), slog.String("error", err.Error()))
-		utils.SendError(w, http.StatusBadRequest, custom_errors.ErrInvalidInput.Error())
-		return
-	}
-
 	claims, err := middlewares.GetClaimsFromContext(r.Context())
 	if err != nil {
 		h.log.Debug("No user claims in context", slog.String("error", err.Error()))
@@ -49,27 +35,14 @@ func (h *NotificationHandler) ReadAllUserNotifications(w http.ResponseWriter, r 
 		return
 	}
 
-	if claims.UserID != userID {
-		h.log.Debug(
-			"User not authorized to mark notifications as read for other users",
-			slog.Int64("request_user_id", userID),
-			slog.Int64("authenticated_user_id", claims.UserID),
-		)
-		utils.SendError(w, http.StatusForbidden, custom_errors.ErrInsufficientRights.Error())
-		return
-	}
-
-	err = h.notificationClient.ReadAllUserNotifications(r.Context(), userID)
+	err = h.notificationClient.ReadAllUserNotifications(r.Context(), claims.UserID)
 	if err != nil {
-		h.log.Error("Failed to mark all notifications as read", slog.Int64("user_id", userID), slog.String("error", err.Error()))
+		h.log.Error("Failed to mark all notifications as read", slog.Int64("user_id", claims.UserID), slog.String("error", err.Error()))
 
 		if st, ok := status.FromError(err); ok {
 			switch st.Code() {
 			case codes.NotFound:
-				utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
-				return
-			case codes.PermissionDenied:
-				utils.SendError(w, http.StatusForbidden, custom_errors.ErrInsufficientRights.Error())
+				utils.SendError(w, http.StatusNotFound, custom_errors.ErrNotificationNotFound.Error())
 				return
 			case codes.Internal:
 				utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
@@ -78,11 +51,8 @@ func (h *NotificationHandler) ReadAllUserNotifications(w http.ResponseWriter, r 
 		}
 
 		switch {
-		case errors.Is(err, custom_errors.ErrUserNotFound):
-			utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
-			return
-		case errors.Is(err, custom_errors.ErrNotificationAccessDenied):
-			utils.SendError(w, http.StatusForbidden, custom_errors.ErrNotificationAccessDenied.Error())
+		case errors.Is(err, custom_errors.ErrNotificationNotFound):
+			utils.SendError(w, http.StatusNotFound, custom_errors.ErrNotificationNotFound.Error())
 			return
 		default:
 			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())

--- a/internal/handlers/notification/read_notification.go
+++ b/internal/handlers/notification/read_notification.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type ReadNotificationResponse struct {
@@ -29,6 +27,7 @@ type ReadNotificationResponse struct {
 // @Param notification_id path int true "Notification ID"
 // @Success 200 {object} ReadNotificationResponse "Notification marked as read"
 // @Failure 400 {object} map[string]string "Bad request"
+// @Failure 401 {object} map[string]string "Unauthorized"
 // @Failure 403 {object} map[string]string "Forbidden"
 // @Failure 404 {object} map[string]string "Notification not found"
 // @Failure 500 {object} map[string]string "Internal server error"
@@ -52,20 +51,16 @@ func (h *NotificationHandler) ReadNotification(w http.ResponseWriter, r *http.Re
 	notification, err := h.notificationClient.GetNotificationDetails(r.Context(), notificationID)
 	if err != nil {
 		h.log.Error("Failed to get notification details for read", slog.Int64("notification_id", notificationID), slog.String("error", err.Error()))
-		if st, ok := status.FromError(err); ok {
-			switch st.Code() {
-			case codes.NotFound:
-				utils.SendError(w, http.StatusNotFound, custom_errors.ErrNotificationNotFound.Error())
-				return
-			case codes.Internal:
-				utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
-				return
-			}
-		}
 
 		switch {
 		case errors.Is(err, custom_errors.ErrNotificationNotFound):
 			utils.SendError(w, http.StatusNotFound, custom_errors.ErrNotificationNotFound.Error())
+			return
+		case errors.Is(err, custom_errors.ErrValidationFailed):
+			utils.SendError(w, http.StatusBadRequest, custom_errors.ErrValidationFailed.Error())
+			return
+		case errors.Is(err, custom_errors.ErrNotificationAccessDenied):
+			utils.SendError(w, http.StatusForbidden, custom_errors.ErrNotificationAccessDenied.Error())
 			return
 		default:
 			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
@@ -95,22 +90,24 @@ func (h *NotificationHandler) ReadNotification(w http.ResponseWriter, r *http.Re
 	err = h.notificationClient.ReadNotification(r.Context(), notificationID)
 	if err != nil {
 		h.log.Error("Failed to mark notification as read", slog.Int64("notification_id", notificationID), slog.String("error", err.Error()))
-		if st, ok := status.FromError(err); ok {
-			switch st.Code() {
-			case codes.NotFound:
-				utils.SendError(w, http.StatusNotFound, custom_errors.ErrNotificationNotFound.Error())
-				return
-			case codes.PermissionDenied:
-				utils.SendError(w, http.StatusForbidden, custom_errors.ErrInsufficientRights.Error())
-				return
-			case codes.Internal:
-				utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
-				return
-			}
-		}
 
-		utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
-		return
+		switch {
+		case errors.Is(err, custom_errors.ErrNotificationNotFound):
+			utils.SendError(w, http.StatusNotFound, custom_errors.ErrNotificationNotFound.Error())
+			return
+		case errors.Is(err, custom_errors.ErrValidationFailed):
+			utils.SendError(w, http.StatusBadRequest, custom_errors.ErrValidationFailed.Error())
+			return
+		case errors.Is(err, custom_errors.ErrNotificationAccessDenied):
+			utils.SendError(w, http.StatusForbidden, custom_errors.ErrNotificationAccessDenied.Error())
+			return
+		case errors.Is(err, custom_errors.ErrExternalServiceTimeout):
+			utils.SendError(w, http.StatusGatewayTimeout, custom_errors.ErrExternalServiceTimeout.Error())
+			return
+		default:
+			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
+			return
+		}
 	}
 
 	response := ReadNotificationResponse{

--- a/internal/handlers/notification/send_notification.go
+++ b/internal/handlers/notification/send_notification.go
@@ -80,7 +80,7 @@ func (h *NotificationHandler) SendNotification(w http.ResponseWriter, r *http.Re
 				utils.SendError(w, http.StatusGatewayTimeout, custom_errors.ErrExternalServiceTimeout.Error())
 				return
 			case codes.Unimplemented:
-				utils.SendError(w, http.StatusNotImplemented, "Notification type not implemented")
+				utils.SendError(w, http.StatusNotImplemented, custom_errors.ErrNotificationInvalidType.Error())
 				return
 			case codes.Internal:
 				utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())


### PR DESCRIPTION
This pull request introduces changes to simplify the notification API by removing the `user_id` path parameter from several endpoints and updating error handling to align with the new structure. It also improves the documentation and error responses for better clarity and consistency.

### API Endpoint Updates:
* Removed the `user_id` path parameter from the following endpoints: `/notification/feed`, `/notification/read-all`, and `/notification/unread-count`. These endpoints now operate without requiring a user ID in the path. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L376-R376) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L452-R436) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L600-R557); `docs/swagger.json`: [[4]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L370-R370) [[5]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L446-R430) [[6]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L594-R551); `docs/swagger.yaml`: [[7]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L966-L976) [[8]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L1015-R1023) [[9]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L1110-L1120); `internal/api/router.go`: [[10]](diffhunk://#diff-d6605b19340f42c0e80ddbc341238970e4996bf5ad100cba281f231f63276e9eL140-R143)

### Error Handling Improvements:
* Updated error responses for better accuracy:
  - Changed the "User not found" error to "Notification not found" in the `/read-all` endpoint. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L470-R462); `docs/swagger.json`: [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L464-R456); `docs/swagger.yaml`: [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L1015-R1023)
  - Added a `401 Unauthorized` response to applicable endpoints. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R790-R798); `docs/swagger.json`: [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R784-R792); `docs/swagger.yaml`: [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R943-R948)
  - Enhanced error handling in `GetNotificationDetails` to include a `400 Bad Request` response for invalid arguments. (`internal/handlers/notification/get_notification_details.go`: [internal/handlers/notification/get_notification_details.goR55-R57](diffhunk://#diff-1a885a61a1955cf5050763de88630583c7f1b52bc16616ed0307003b97aa6771R55-R57))

### Documentation Updates:
* Updated OpenAPI documentation (`docs.go`, `swagger.json`, and `swagger.yaml`) to reflect the removal of the `user_id` parameter and the revised error responses. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L395-L401) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L618-L626); `docs/swagger.json`: [[3]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L389-L395) [[4]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L612-L620); `docs/swagger.yaml`: [[5]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L998-L1003) [[6]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L1134-L1139)

### Codebase Adjustments:
* Removed references to `user_id` in the notification client and updated error mappings to reflect the new API behavior. (`internal/clients/notification/notification.go`: [[1]](diffhunk://#diff-a5b5fb68aaa7e53c6b4143ca0d5443a23efbe1ef565d1b3c47f82d4853303c41L50-R50) [[2]](diffhunk://#diff-a5b5fb68aaa7e53c6b4143ca0d5443a23efbe1ef565d1b3c47f82d4853303c41L215-R215)