### PR TITLE
Fix/follow unfollow workflow

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2713,6 +2713,12 @@ const docTemplate = `{
                         "type": "integer"
                     }
                 },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
                 "total": {
                     "type": "integer"
                 }
@@ -2726,6 +2732,12 @@ const docTemplate = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
                 },
                 "total": {
                     "type": "integer"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -714,6 +714,15 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
@@ -1294,6 +1303,180 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/relation/{user_id}/followees": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get list of users that the user is following",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "relation"
+                ],
+                "summary": "Get user followees",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Limit for pagination",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Followees retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/relation_handler.GetFolloweesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/relation/{user_id}/followers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get list of user followers by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "relation"
+                ],
+                "summary": "Get user followers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Limit for pagination",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Followers retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/relation_handler.GetFollowersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2501,6 +2684,34 @@ const docTemplate = `{
             "properties": {
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "relation_handler.GetFolloweesResponse": {
+            "type": "object",
+            "properties": {
+                "followee_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "relation_handler.GetFollowersResponse": {
+            "type": "object",
+            "properties": {
+                "follower_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1360,65 +1360,7 @@ const docTemplate = `{
         },
         "/relation/{user_id}/followees": {
             "get": {
-                "description": "Get list of users that the user is following",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "relation"
-                ],
-                "summary": "Get user followees",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Limit for pagination",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 1,
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "Followees retrieved successfully",
-                        "schema": {
-                            "$ref": "#/definitions/relation_handler.GetFolloweesResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
                     "404": {
                         "description": "User not found",
                         "schema": {
@@ -1442,65 +1384,7 @@ const docTemplate = `{
         },
         "/relation/{user_id}/followers": {
             "get": {
-                "description": "Get list of user followers by user ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "relation"
-                ],
-                "summary": "Get user followers",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Limit for pagination",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 1,
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "Followers retrieved successfully",
-                        "schema": {
-                            "$ref": "#/definitions/relation_handler.GetFollowersResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
                     "404": {
                         "description": "User not found",
                         "schema": {
@@ -2701,46 +2585,6 @@ const docTemplate = `{
             "properties": {
                 "message": {
                     "type": "string"
-                }
-            }
-        },
-        "relation_handler.GetFolloweesResponse": {
-            "type": "object",
-            "properties": {
-                "followee_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "limit": {
-                    "type": "integer"
-                },
-                "page": {
-                    "type": "integer"
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "relation_handler.GetFollowersResponse": {
-            "type": "object",
-            "properties": {
-                "follower_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "limit": {
-                    "type": "integer"
-                },
-                "page": {
-                    "type": "integer"
-                },
-                "total": {
-                    "type": "integer"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1244,8 +1244,26 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "404": {
                         "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Already following",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -1310,8 +1328,17 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "404": {
-                        "description": "User not found",
+                        "description": "User not found or relation not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -1333,11 +1360,6 @@ const docTemplate = `{
         },
         "/relation/{user_id}/followees": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Get list of users that the user is following",
                 "consumes": [
                     "application/json"
@@ -1420,11 +1442,6 @@ const docTemplate = `{
         },
         "/relation/{user_id}/followers": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Get list of user followers by user ID",
                 "consumes": [
                     "application/json"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1238,8 +1238,26 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "404": {
                         "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Already following",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -1304,8 +1322,17 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "404": {
-                        "description": "User not found",
+                        "description": "User not found or relation not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -1327,11 +1354,6 @@
         },
         "/relation/{user_id}/followees": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Get list of users that the user is following",
                 "consumes": [
                     "application/json"
@@ -1414,11 +1436,6 @@
         },
         "/relation/{user_id}/followers": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Get list of user followers by user ID",
                 "consumes": [
                     "application/json"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -708,6 +708,15 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
@@ -1288,6 +1297,180 @@
                     },
                     "400": {
                         "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/relation/{user_id}/followees": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get list of users that the user is following",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "relation"
+                ],
+                "summary": "Get user followees",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Limit for pagination",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Followees retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/relation_handler.GetFolloweesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/relation/{user_id}/followers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get list of user followers by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "relation"
+                ],
+                "summary": "Get user followers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Limit for pagination",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Followers retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/relation_handler.GetFollowersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2495,6 +2678,34 @@
             "properties": {
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "relation_handler.GetFolloweesResponse": {
+            "type": "object",
+            "properties": {
+                "followee_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "relation_handler.GetFollowersResponse": {
+            "type": "object",
+            "properties": {
+                "follower_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2707,6 +2707,12 @@
                         "type": "integer"
                     }
                 },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
                 "total": {
                     "type": "integer"
                 }
@@ -2720,6 +2726,12 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
                 },
                 "total": {
                     "type": "integer"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1354,65 +1354,7 @@
         },
         "/relation/{user_id}/followees": {
             "get": {
-                "description": "Get list of users that the user is following",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "relation"
-                ],
-                "summary": "Get user followees",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Limit for pagination",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 1,
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "Followees retrieved successfully",
-                        "schema": {
-                            "$ref": "#/definitions/relation_handler.GetFolloweesResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
                     "404": {
                         "description": "User not found",
                         "schema": {
@@ -1436,65 +1378,7 @@
         },
         "/relation/{user_id}/followers": {
             "get": {
-                "description": "Get list of user followers by user ID",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "relation"
-                ],
-                "summary": "Get user followers",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "User ID",
-                        "name": "user_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Limit for pagination",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 1,
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
-                    "200": {
-                        "description": "Followers retrieved successfully",
-                        "schema": {
-                            "$ref": "#/definitions/relation_handler.GetFollowersResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
                     "404": {
                         "description": "User not found",
                         "schema": {
@@ -2695,46 +2579,6 @@
             "properties": {
                 "message": {
                     "type": "string"
-                }
-            }
-        },
-        "relation_handler.GetFolloweesResponse": {
-            "type": "object",
-            "properties": {
-                "followee_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "limit": {
-                    "type": "integer"
-                },
-                "page": {
-                    "type": "integer"
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "relation_handler.GetFollowersResponse": {
-            "type": "object",
-            "properties": {
-                "follower_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "limit": {
-                    "type": "integer"
-                },
-                "page": {
-                    "type": "integer"
-                },
-                "total": {
-                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -395,6 +395,24 @@ definitions:
       message:
         type: string
     type: object
+  relation_handler.GetFolloweesResponse:
+    properties:
+      followee_ids:
+        items:
+          type: integer
+        type: array
+      total:
+        type: integer
+    type: object
+  relation_handler.GetFollowersResponse:
+    properties:
+      follower_ids:
+        items:
+          type: integer
+        type: array
+      total:
+        type: integer
+    type: object
   relation_handler.UnfollowRequest:
     properties:
       followee_id:
@@ -843,6 +861,12 @@ paths:
             $ref: '#/definitions/notification_handler.RemoveNotificationResponse'
         "400":
           description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
           schema:
             additionalProperties:
               type: string
@@ -1351,6 +1375,120 @@ paths:
       summary: List posts with filters
       tags:
       - posts
+  /relation/{user_id}/followees:
+    get:
+      consumes:
+      - application/json
+      description: Get list of users that the user is following
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: integer
+      - default: 20
+        description: Limit for pagination
+        in: query
+        name: limit
+        type: integer
+      - default: 1
+        description: Page number
+        in: query
+        name: page
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Followees retrieved successfully
+          schema:
+            $ref: '#/definitions/relation_handler.GetFolloweesResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: User not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get user followees
+      tags:
+      - relation
+  /relation/{user_id}/followers:
+    get:
+      consumes:
+      - application/json
+      description: Get list of user followers by user ID
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: integer
+      - default: 20
+        description: Limit for pagination
+        in: query
+        name: limit
+        type: integer
+      - default: 1
+        description: Page number
+        in: query
+        name: page
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Followers retrieved successfully
+          schema:
+            $ref: '#/definitions/relation_handler.GetFollowersResponse'
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: User not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get user followers
+      tags:
+      - relation
   /relation/follow:
     post:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1427,8 +1427,6 @@ paths:
             additionalProperties:
               type: string
             type: object
-      security:
-      - BearerAuth: []
       summary: Get user followees
       tags:
       - relation
@@ -1484,8 +1482,6 @@ paths:
             additionalProperties:
               type: string
             type: object
-      security:
-      - BearerAuth: []
       summary: Get user followers
       tags:
       - relation
@@ -1514,8 +1510,20 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "404":
           description: User not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Already following
           schema:
             additionalProperties:
               type: string
@@ -1556,8 +1564,14 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "404":
-          description: User not found
+          description: User not found or relation not found
           schema:
             additionalProperties:
               type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -401,6 +401,10 @@ definitions:
         items:
           type: integer
         type: array
+      limit:
+        type: integer
+      page:
+        type: integer
       total:
         type: integer
     type: object
@@ -410,6 +414,10 @@ definitions:
         items:
           type: integer
         type: array
+      limit:
+        type: integer
+      page:
+        type: integer
       total:
         type: integer
     type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -395,32 +395,6 @@ definitions:
       message:
         type: string
     type: object
-  relation_handler.GetFolloweesResponse:
-    properties:
-      followee_ids:
-        items:
-          type: integer
-        type: array
-      limit:
-        type: integer
-      page:
-        type: integer
-      total:
-        type: integer
-    type: object
-  relation_handler.GetFollowersResponse:
-    properties:
-      follower_ids:
-        items:
-          type: integer
-        type: array
-      limit:
-        type: integer
-      page:
-        type: integer
-      total:
-        type: integer
-    type: object
   relation_handler.UnfollowRequest:
     properties:
       followee_id:
@@ -1385,44 +1359,7 @@ paths:
       - posts
   /relation/{user_id}/followees:
     get:
-      consumes:
-      - application/json
-      description: Get list of users that the user is following
-      parameters:
-      - description: User ID
-        in: path
-        name: user_id
-        required: true
-        type: integer
-      - default: 20
-        description: Limit for pagination
-        in: query
-        name: limit
-        type: integer
-      - default: 1
-        description: Page number
-        in: query
-        name: page
-        type: integer
-      produces:
-      - application/json
       responses:
-        "200":
-          description: Followees retrieved successfully
-          schema:
-            $ref: '#/definitions/relation_handler.GetFolloweesResponse'
-        "400":
-          description: Bad request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            additionalProperties:
-              type: string
-            type: object
         "404":
           description: User not found
           schema:
@@ -1435,49 +1372,9 @@ paths:
             additionalProperties:
               type: string
             type: object
-      summary: Get user followees
-      tags:
-      - relation
   /relation/{user_id}/followers:
     get:
-      consumes:
-      - application/json
-      description: Get list of user followers by user ID
-      parameters:
-      - description: User ID
-        in: path
-        name: user_id
-        required: true
-        type: integer
-      - default: 20
-        description: Limit for pagination
-        in: query
-        name: limit
-        type: integer
-      - default: 1
-        description: Page number
-        in: query
-        name: page
-        type: integer
-      produces:
-      - application/json
       responses:
-        "200":
-          description: Followers retrieved successfully
-          schema:
-            $ref: '#/definitions/relation_handler.GetFollowersResponse'
-        "400":
-          description: Bad request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            additionalProperties:
-              type: string
-            type: object
         "404":
           description: User not found
           schema:
@@ -1490,9 +1387,6 @@ paths:
             additionalProperties:
               type: string
             type: object
-      summary: Get user followers
-      tags:
-      - relation
   /relation/follow:
     post:
       consumes:

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -125,6 +125,8 @@ func (r *Router) setupRelationRoutes(jwtMiddleware func(next http.Handler) http.
 		r.Use(jwtMiddleware)
 		r.Post("/follow", relationHandler.Follow)
 		r.Post("/unfollow", relationHandler.Unfollow)
+		r.Get("/{user_id}/followees", relationHandler.GetFollowees)
+		r.Get("/{user_id}/followers", relationHandler.GetFollowers)
 	})
 
 	return router

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -120,13 +120,12 @@ func (r *Router) setupPostRoutes(jwtMiddleware func(next http.Handler) http.Hand
 func (r *Router) setupRelationRoutes(jwtMiddleware func(next http.Handler) http.Handler) http.Handler {
 	relationHandler := relation_handler.NewRelationHandler(r.relationClient, r.log)
 	router := chi.NewRouter()
-
+	router.Get("/{user_id}/followees", relationHandler.GetFollowees)
+	router.Get("/{user_id}/followers", relationHandler.GetFollowers)
 	router.Group(func(r chi.Router) {
 		r.Use(jwtMiddleware)
 		r.Post("/follow", relationHandler.Follow)
 		r.Post("/unfollow", relationHandler.Unfollow)
-		r.Get("/{user_id}/followees", relationHandler.GetFollowees)
-		r.Get("/{user_id}/followers", relationHandler.GetFollowers)
 	})
 
 	return router

--- a/internal/clients/relation/relation.go
+++ b/internal/clients/relation/relation.go
@@ -37,7 +37,17 @@ func (c *relationClient) Follow(ctx context.Context, followerID, followeeID int6
 		if st, ok := status.FromError(err); ok {
 			switch st.Code() {
 			case codes.InvalidArgument:
+				errMsg := st.Message()
+				if errMsg == custom_errors.ErrSelfFollow.Error() {
+					return custom_errors.ErrSelfFollow
+				}
 				return custom_errors.ErrValidationFailed
+			case codes.AlreadyExists:
+				return custom_errors.ErrAlreadyFollowing
+			case codes.NotFound:
+				return custom_errors.ErrUserNotFound
+			case codes.Internal:
+				return custom_errors.ErrExternalServiceError
 			default:
 				return custom_errors.ErrExternalServiceError
 			}
@@ -58,7 +68,19 @@ func (c *relationClient) Unfollow(ctx context.Context, followerID, followeeID in
 		if st, ok := status.FromError(err); ok {
 			switch st.Code() {
 			case codes.InvalidArgument:
+				errMsg := st.Message()
+				if errMsg == custom_errors.ErrSelfUnfollow.Error() {
+					return custom_errors.ErrSelfUnfollow
+				}
 				return custom_errors.ErrValidationFailed
+			case codes.NotFound:
+				errMsg := st.Message()
+				if errMsg == custom_errors.ErrFollowRelationNotFound.Error() {
+					return custom_errors.ErrFollowRelationNotFound
+				}
+				return custom_errors.ErrUserNotFound
+			case codes.Internal:
+				return custom_errors.ErrExternalServiceError
 			default:
 				return custom_errors.ErrExternalServiceError
 			}
@@ -81,6 +103,14 @@ func (c *relationClient) GetFollowers(ctx context.Context, followeeID int64, lim
 			switch st.Code() {
 			case codes.InvalidArgument:
 				return nil, custom_errors.ErrValidationFailed
+			case codes.NotFound:
+				return nil, custom_errors.ErrUserNotFound
+			case codes.Internal:
+				errMsg := st.Message()
+				if errMsg == custom_errors.ErrDatabaseQuery.Error() {
+					return nil, custom_errors.ErrDatabaseQuery
+				}
+				return nil, custom_errors.ErrExternalServiceError
 			default:
 				return nil, custom_errors.ErrExternalServiceError
 			}
@@ -103,6 +133,14 @@ func (c *relationClient) GetFollowees(ctx context.Context, followerID int64, lim
 			switch st.Code() {
 			case codes.InvalidArgument:
 				return nil, custom_errors.ErrValidationFailed
+			case codes.NotFound:
+				return nil, custom_errors.ErrUserNotFound
+			case codes.Internal:
+				errMsg := st.Message()
+				if errMsg == custom_errors.ErrDatabaseQuery.Error() {
+					return nil, custom_errors.ErrDatabaseQuery
+				}
+				return nil, custom_errors.ErrExternalServiceError
 			default:
 				return nil, custom_errors.ErrExternalServiceError
 			}

--- a/internal/custom_errors/errors.go
+++ b/internal/custom_errors/errors.go
@@ -110,6 +110,7 @@ var (
 // Follower relation errors
 var (
 	ErrSelfFollow               = errors.New("cannot follow yourself")
+	ErrSelfUnfollow             = errors.New("cannot unfollow yourself")
 	ErrFollowRelationExists     = errors.New("follow relation already exists")
 	ErrFollowRelationNotFound   = errors.New("follow relation not found")
 	ErrFollowRelationCreateFail = errors.New("failed to create follow relation")

--- a/internal/handlers/relation/get_followees.go
+++ b/internal/handlers/relation/get_followees.go
@@ -22,7 +22,6 @@ type GetFolloweesResponse struct {
 // @Tags relation
 // @Accept json
 // @Produce json
-// @Security BearerAuth
 // @Param user_id path int true "User ID"
 // @Param limit query int false "Limit for pagination" default(20)
 // @Param page query int false "Page number" default(1)
@@ -74,6 +73,9 @@ func (h *RelationHandler) GetFollowees(w http.ResponseWriter, r *http.Request) {
 			return
 		case errors.Is(err, custom_errors.ErrUserNotFound):
 			utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
+			return
+		case errors.Is(err, custom_errors.ErrDatabaseQuery):
+			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrDatabaseQuery.Error())
 			return
 		default:
 			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())

--- a/internal/handlers/relation/get_followees.go
+++ b/internal/handlers/relation/get_followees.go
@@ -14,6 +14,8 @@ import (
 type GetFolloweesResponse struct {
 	FolloweeIDs []int64 `json:"followee_ids"`
 	Total       int32   `json:"total"`
+	Page        int32   `json:"page"`
+	Limit       int32   `json:"limit"`
 }
 
 // GetFollowees godoc
@@ -86,6 +88,8 @@ func (h *RelationHandler) GetFollowees(w http.ResponseWriter, r *http.Request) {
 	response := GetFolloweesResponse{
 		FolloweeIDs: followeeIDs,
 		Total:       int32(len(followeeIDs)),
+		Page:        page,
+		Limit:       limit,
 	}
 	utils.Send(w, http.StatusOK, response)
 }

--- a/internal/handlers/relation/get_followees.go
+++ b/internal/handlers/relation/get_followees.go
@@ -1,0 +1,89 @@
+package relation_handler
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"pinstack-api-gateway/internal/custom_errors"
+	"pinstack-api-gateway/internal/utils"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type GetFolloweesResponse struct {
+	FolloweeIDs []int64 `json:"followee_ids"`
+	Total       int32   `json:"total"`
+}
+
+// GetFollowees godoc
+// @Summary Get user followees
+// @Description Get list of users that the user is following
+// @Tags relation
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param user_id path int true "User ID"
+// @Param limit query int false "Limit for pagination" default(20)
+// @Param page query int false "Page number" default(1)
+// @Success 200 {object} GetFolloweesResponse "Followees retrieved successfully"
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 404 {object} map[string]string "User not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /relation/{user_id}/followees [get]
+func (h *RelationHandler) GetFollowees(w http.ResponseWriter, r *http.Request) {
+	userIDStr := chi.URLParam(r, "user_id")
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		h.log.Debug("Failed to parse user ID", slog.String("user_id", userIDStr), slog.String("error", err.Error()))
+		utils.SendError(w, http.StatusBadRequest, custom_errors.ErrInvalidInput.Error())
+		return
+	}
+
+	if userID <= 0 {
+		h.log.Debug("Invalid user ID", slog.Int64("user_id", userID))
+		utils.SendError(w, http.StatusBadRequest, custom_errors.ErrValidationFailed.Error())
+		return
+	}
+
+	limitStr := r.URL.Query().Get("limit")
+	pageStr := r.URL.Query().Get("page")
+
+	limit := int32(20) // default
+	if limitStr != "" {
+		if l, err := strconv.ParseInt(limitStr, 10, 32); err == nil && l > 0 && l <= 100 {
+			limit = int32(l)
+		}
+	}
+
+	page := int32(1) // default
+	if pageStr != "" {
+		if p, err := strconv.ParseInt(pageStr, 10, 32); err == nil && p > 0 {
+			page = int32(p)
+		}
+	}
+
+	followeeIDs, err := h.relationClient.GetFollowees(r.Context(), userID, limit, page)
+	if err != nil {
+		h.log.Error("Failed to get followees", slog.Int64("user_id", userID), slog.String("error", err.Error()))
+
+		switch {
+		case errors.Is(err, custom_errors.ErrValidationFailed):
+			utils.SendError(w, http.StatusBadRequest, custom_errors.ErrValidationFailed.Error())
+			return
+		case errors.Is(err, custom_errors.ErrUserNotFound):
+			utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
+			return
+		default:
+			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())
+			return
+		}
+	}
+
+	response := GetFolloweesResponse{
+		FolloweeIDs: followeeIDs,
+		Total:       int32(len(followeeIDs)),
+	}
+	utils.Send(w, http.StatusOK, response)
+}

--- a/internal/handlers/relation/get_followees.go
+++ b/internal/handlers/relation/get_followees.go
@@ -29,7 +29,7 @@ type GetFolloweesResponse struct {
 // @Param page query int false "Page number" default(1)
 // @Success 200 {object} GetFolloweesResponse "Followees retrieved successfully"
 // @Failure 400 {object} map[string]string "Bad request"
-// @Failure 401 {object} map[string]string "Unauthorized"
+
 // @Failure 404 {object} map[string]string "User not found"
 // @Failure 500 {object} map[string]string "Internal server error"
 // @Router /relation/{user_id}/followees [get]

--- a/internal/handlers/relation/get_followers.go
+++ b/internal/handlers/relation/get_followers.go
@@ -29,7 +29,7 @@ type GetFollowersResponse struct {
 // @Param page query int false "Page number" default(1)
 // @Success 200 {object} GetFollowersResponse "Followers retrieved successfully"
 // @Failure 400 {object} map[string]string "Bad request"
-// @Failure 401 {object} map[string]string "Unauthorized"
+
 // @Failure 404 {object} map[string]string "User not found"
 // @Failure 500 {object} map[string]string "Internal server error"
 // @Router /relation/{user_id}/followers [get]

--- a/internal/handlers/relation/get_followers.go
+++ b/internal/handlers/relation/get_followers.go
@@ -22,7 +22,6 @@ type GetFollowersResponse struct {
 // @Tags relation
 // @Accept json
 // @Produce json
-// @Security BearerAuth
 // @Param user_id path int true "User ID"
 // @Param limit query int false "Limit for pagination" default(20)
 // @Param page query int false "Page number" default(1)
@@ -74,6 +73,9 @@ func (h *RelationHandler) GetFollowers(w http.ResponseWriter, r *http.Request) {
 			return
 		case errors.Is(err, custom_errors.ErrUserNotFound):
 			utils.SendError(w, http.StatusNotFound, custom_errors.ErrUserNotFound.Error())
+			return
+		case errors.Is(err, custom_errors.ErrDatabaseQuery):
+			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrDatabaseQuery.Error())
 			return
 		default:
 			utils.SendError(w, http.StatusInternalServerError, custom_errors.ErrExternalServiceError.Error())

--- a/internal/handlers/relation/get_followers.go
+++ b/internal/handlers/relation/get_followers.go
@@ -14,6 +14,8 @@ import (
 type GetFollowersResponse struct {
 	FollowerIDs []int64 `json:"follower_ids"`
 	Total       int32   `json:"total"`
+	Page        int32   `json:"page"`
+	Limit       int32   `json:"limit"`
 }
 
 // GetFollowers godoc
@@ -86,6 +88,8 @@ func (h *RelationHandler) GetFollowers(w http.ResponseWriter, r *http.Request) {
 	response := GetFollowersResponse{
 		FollowerIDs: followerIDs,
 		Total:       int32(len(followerIDs)),
+		Page:        page,
+		Limit:       limit,
 	}
 	utils.Send(w, http.StatusOK, response)
 }


### PR DESCRIPTION
This pull request enhances the API documentation by adding new endpoints and response definitions for user relationships, including followees and followers, and by expanding the set of error responses for existing endpoints. The most significant changes involve updates to the `docs.go`, `swagger.json`, and `swagger.yaml` files to reflect these additions.

### New Endpoints and Response Definitions:

* Added two new endpoints, `/relation/{user_id}/followees` and `/relation/{user_id}/followers`, to retrieve lists of followees and followers for a given user. These endpoints include support for pagination and return detailed response schemas. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R1331-R1503) `docs/swagger.json`: [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R1325-R1497) `docs/swagger.yaml`: [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R868-R873)
* Introduced new response definitions, `relation_handler.GetFolloweesResponse` and `relation_handler.GetFollowersResponse`, to structure the data returned by the new endpoints. These include arrays of user IDs and a total count. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R2707-R2734) `docs/swagger.json`: [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R2701-R2728) `docs/swagger.yaml`: [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R398-R415)

### Expanded Error Responses:

* Added a `401 Unauthorized` error response to multiple endpoints, providing a standardized schema for unauthorized access errors. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R717-R725) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R1247-R1255) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R1331-R1503); `docs/swagger.json`: [[4]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R711-R719) [[5]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R1241-R1249)
* Added a `409 Already following` error response to endpoints related to following actions, ensuring proper handling of duplicate follow attempts. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R1265-R1273) `docs/swagger.json`: [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R1259-R1267)

These improvements make the API documentation more comprehensive and user-friendly while ensuring that error handling is well-documented.