### PR TITLE
Refactor/task31 get followers followees

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2235,6 +2235,20 @@ const docTemplate = `{
                 }
             }
         },
+        "models.RelationUser": {
+            "type": "object",
+            "properties": {
+                "avatar_url": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "notification_handler.GetUnreadCountResponse": {
             "type": "object",
             "properties": {
@@ -2689,10 +2703,10 @@ const docTemplate = `{
         "relation_handler.GetFolloweesResponse": {
             "type": "object",
             "properties": {
-                "followee_ids": {
+                "followees": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "$ref": "#/definitions/models.RelationUser"
                     }
                 },
                 "limit": {
@@ -2709,10 +2723,10 @@ const docTemplate = `{
         "relation_handler.GetFollowersResponse": {
             "type": "object",
             "properties": {
-                "follower_ids": {
+                "followers": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "$ref": "#/definitions/models.RelationUser"
                     }
                 },
                 "limit": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2229,6 +2229,20 @@
                 }
             }
         },
+        "models.RelationUser": {
+            "type": "object",
+            "properties": {
+                "avatar_url": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "notification_handler.GetUnreadCountResponse": {
             "type": "object",
             "properties": {
@@ -2683,10 +2697,10 @@
         "relation_handler.GetFolloweesResponse": {
             "type": "object",
             "properties": {
-                "followee_ids": {
+                "followees": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "$ref": "#/definitions/models.RelationUser"
                     }
                 },
                 "limit": {
@@ -2703,10 +2717,10 @@
         "relation_handler.GetFollowersResponse": {
             "type": "object",
             "properties": {
-                "follower_ids": {
+                "followers": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "$ref": "#/definitions/models.RelationUser"
                     }
                 },
                 "limit": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -99,6 +99,15 @@ definitions:
       user_id:
         type: integer
     type: object
+  models.RelationUser:
+    properties:
+      avatar_url:
+        type: string
+      id:
+        type: integer
+      username:
+        type: string
+    type: object
   notification_handler.GetUnreadCountResponse:
     properties:
       count:
@@ -397,9 +406,9 @@ definitions:
     type: object
   relation_handler.GetFolloweesResponse:
     properties:
-      followee_ids:
+      followees:
         items:
-          type: integer
+          $ref: '#/definitions/models.RelationUser'
         type: array
       limit:
         type: integer
@@ -410,9 +419,9 @@ definitions:
     type: object
   relation_handler.GetFollowersResponse:
     properties:
-      follower_ids:
+      followers:
         items:
-          type: integer
+          $ref: '#/definitions/models.RelationUser'
         type: array
       limit:
         type: integer

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/prometheus/client_golang v1.22.0
-	github.com/soloda1/pinstack-proto-definitions v0.1.17
+	github.com/soloda1/pinstack-proto-definitions v0.1.19
 	github.com/spf13/viper v1.20.1
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag v1.16.4

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
-github.com/soloda1/pinstack-proto-definitions v0.1.17 h1:c6evxxHF4FaOtbcjWXBSxVDxnpCskDpiFQJkNEgPUBw=
-github.com/soloda1/pinstack-proto-definitions v0.1.17/go.mod h1:Jl7Cv/0eQDLtxI5HdRANm6HYbSjX1x97Za4XRUySwrM=
+github.com/soloda1/pinstack-proto-definitions v0.1.19 h1:TRBG1HJcBvUqFy8u5OdF5z4ZX5YzxLDxhOKV+CFUoXs=
+github.com/soloda1/pinstack-proto-definitions v0.1.19/go.mod h1:Jl7Cv/0eQDLtxI5HdRANm6HYbSjX1x97Za4XRUySwrM=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=

--- a/internal/clients/relation/interface.go
+++ b/internal/clients/relation/interface.go
@@ -1,10 +1,13 @@
 package relation_client
 
-import "context"
+import (
+	"context"
+	"pinstack-api-gateway/internal/models"
+)
 
 type RelationClient interface {
 	Follow(ctx context.Context, followerID, followeeID int64) error
 	Unfollow(ctx context.Context, followerID, followeeID int64) error
-	GetFollowers(ctx context.Context, followeeID int64, limit, page int32) ([]int64, error)
-	GetFollowees(ctx context.Context, followerID int64, limit, page int32) ([]int64, error)
+	GetFollowers(ctx context.Context, followeeID int64, limit, page int32) ([]*models.RelationUser, int64, error)
+	GetFollowees(ctx context.Context, followerID int64, limit, page int32) ([]*models.RelationUser, int64, error)
 }

--- a/internal/handlers/relation/get_followees.go
+++ b/internal/handlers/relation/get_followees.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"pinstack-api-gateway/internal/custom_errors"
+	"pinstack-api-gateway/internal/models"
 	"pinstack-api-gateway/internal/utils"
 	"strconv"
 
@@ -12,10 +13,10 @@ import (
 )
 
 type GetFolloweesResponse struct {
-	FolloweeIDs []int64 `json:"followee_ids"`
-	Total       int32   `json:"total"`
-	Page        int32   `json:"page"`
-	Limit       int32   `json:"limit"`
+	Followees []*models.RelationUser `json:"followees"`
+	Total     int64                  `json:"total"`
+	Page      int32                  `json:"page"`
+	Limit     int32                  `json:"limit"`
 }
 
 // GetFollowees godoc
@@ -64,7 +65,7 @@ func (h *RelationHandler) GetFollowees(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	followeeIDs, err := h.relationClient.GetFollowees(r.Context(), userID, limit, page)
+	followees, total, err := h.relationClient.GetFollowees(r.Context(), userID, limit, page)
 	if err != nil {
 		h.log.Error("Failed to get followees", slog.Int64("user_id", userID), slog.String("error", err.Error()))
 
@@ -85,10 +86,10 @@ func (h *RelationHandler) GetFollowees(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := GetFolloweesResponse{
-		FolloweeIDs: followeeIDs,
-		Total:       int32(len(followeeIDs)),
-		Page:        page,
-		Limit:       limit,
+		Followees: followees,
+		Total:     total,
+		Page:      page,
+		Limit:     limit,
 	}
 	utils.Send(w, http.StatusOK, response)
 }

--- a/internal/handlers/relation/get_followers.go
+++ b/internal/handlers/relation/get_followers.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"pinstack-api-gateway/internal/custom_errors"
+	"pinstack-api-gateway/internal/models"
 	"pinstack-api-gateway/internal/utils"
 	"strconv"
 
@@ -12,10 +13,10 @@ import (
 )
 
 type GetFollowersResponse struct {
-	FollowerIDs []int64 `json:"follower_ids"`
-	Total       int32   `json:"total"`
-	Page        int32   `json:"page"`
-	Limit       int32   `json:"limit"`
+	Followers []*models.RelationUser `json:"followers"`
+	Total     int64                  `json:"total"`
+	Page      int32                  `json:"page"`
+	Limit     int32                  `json:"limit"`
 }
 
 // GetFollowers godoc
@@ -64,7 +65,7 @@ func (h *RelationHandler) GetFollowers(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	followerIDs, err := h.relationClient.GetFollowers(r.Context(), userID, limit, page)
+	followers, total, err := h.relationClient.GetFollowers(r.Context(), userID, limit, page)
 	if err != nil {
 		h.log.Error("Failed to get followers", slog.Int64("user_id", userID), slog.String("error", err.Error()))
 
@@ -85,10 +86,10 @@ func (h *RelationHandler) GetFollowers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := GetFollowersResponse{
-		FollowerIDs: followerIDs,
-		Total:       int32(len(followerIDs)),
-		Page:        page,
-		Limit:       limit,
+		Followers: followers,
+		Total:     total,
+		Page:      page,
+		Limit:     limit,
 	}
 	utils.Send(w, http.StatusOK, response)
 }

--- a/internal/models/relation.go
+++ b/internal/models/relation.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"time"
+
+	pb "github.com/soloda1/pinstack-proto-definitions/gen/go/pinstack-proto-definitions/relation/v1"
 )
 
 type Follower struct {
@@ -9,4 +11,18 @@ type Follower struct {
 	FollowerID int64     `json:"follower_id"`
 	FolloweeID int64     `json:"followee_id"`
 	CreatedAt  time.Time `json:"created_at"`
+}
+
+type RelationUser struct {
+	ID        int64   `json:"id"`
+	Username  string  `json:"username"`
+	AvatarURL *string `json:"avatar_url,omitempty"`
+}
+
+func RelationUserFromProto(u *pb.User) *RelationUser {
+	return &RelationUser{
+		ID:        u.FollowerId,
+		Username:  u.Username,
+		AvatarURL: u.AvatarUrl,
+	}
 }


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of user relation data (followers and followees) by replacing simple ID-based representations with richer user objects (`RelationUser`). These changes affect the API documentation, client interfaces, and handlers, ensuring consistency across the codebase.

### API Documentation Updates:
* Added a new `models.RelationUser` object to the OpenAPI schema, which includes `id`, `username`, and `avatar_url` properties. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R2238-R2251) `docs/swagger.json`: [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R2232-R2245) `docs/swagger.yaml`: [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R102-R110)
* Updated the `GetFolloweesResponse` and `GetFollowersResponse` schemas to use `RelationUser` objects instead of arrays of integers. (`docs/docs.go`: [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L2692-R2709) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L2712-R2729); `docs/swagger.json`: [[3]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L2686-R2703) [[4]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L2706-R2723); `docs/swagger.yaml`: [[5]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L400-R411) [[6]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L413-R424)

### Client Interface and Implementation Updates:
* Updated the `RelationClient` interface to return `RelationUser` objects and total counts for `GetFollowers` and `GetFollowees`. (`internal/clients/relation/interface.go`: [internal/clients/relation/interface.goL3-R12](diffhunk://#diff-f748236855603966d3f38e3238ca068970f17dbe44fa69083221495ca4d49da7L3-R12))
* Modified the `relationClient` implementation to map protobuf user objects to `RelationUser`. (`internal/clients/relation/relation.go`: [[1]](diffhunk://#diff-9612063c19912db569aa6638eb866c06cc28eedde5ddc281bcdf752e29b21c17L93-R94) [[2]](diffhunk://#diff-9612063c19912db569aa6638eb866c06cc28eedde5ddc281bcdf752e29b21c17L105-R130) [[3]](diffhunk://#diff-9612063c19912db569aa6638eb866c06cc28eedde5ddc281bcdf752e29b21c17L135-R163)

### Handler Updates:
* Updated the `GetFollowees` and `GetFollowers` handlers to return enriched `RelationUser` objects in the API responses. (`internal/handlers/relation/get_followees.go`: [[1]](diffhunk://#diff-9eb1b437441a57c1238350553059ee4af859500c04666fb93a877420c276c39dR8-R17) [[2]](diffhunk://#diff-9eb1b437441a57c1238350553059ee4af859500c04666fb93a877420c276c39dL67-R68) [[3]](diffhunk://#diff-9eb1b437441a57c1238350553059ee4af859500c04666fb93a877420c276c39dL88-R90); `internal/handlers/relation/get_followers.go`: [[4]](diffhunk://#diff-86ab84bafbb13f0fbd7587b4270c569360bc8e658d891ca1640639fd9b7f840bR8-R17) [[5]](diffhunk://#diff-86ab84bafbb13f0fbd7587b4270c569360bc8e658d891ca1640639fd9b7f840bL67-R68) [[6]](diffhunk://#diff-86ab84bafbb13f0fbd7587b4270c569360bc8e658d891ca1640639fd9b7f840bL88-R90)

### Models Enhancements:
* Added a new `RelationUser` struct and a helper function `RelationUserFromProto` to map protobuf user objects to the new struct. (`internal/models/relation.go`: [[1]](diffhunk://#diff-f571e759bc235af409612ef60012b25a7eb2c2fdae5b3d528204192d8273aa61R5-R6) [[2]](diffhunk://#diff-f571e759bc235af409612ef60012b25a7eb2c2fdae5b3d528204192d8273aa61R15-R28)

### Dependency Update:
* Updated the `pinstack-proto-definitions` dependency to version `v0.1.19` to support the new protobuf definitions. (`go.mod`: [go.modL10-R10](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L10-R10))